### PR TITLE
Fix ambiguous ifstream constructor error on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Mac
+.DS_Store
+
+# build artifacts
+/a.out
+/a.out.dSYM
+/config.log
+/config.status
+/include/ptbuildopts.h
+/lib_Darwin_x86_64
+/Makefile
+/make/ptbuildopts.mak
+/make/ptlib-config
+/plugins/config.log
+/plugins/config.status
+/plugins/Makefile
+/plugins/vidinput_dc/Makefile
+/plugins/vidinput_v4l2/Makefile
+/ptlib_cfg.dxy
+/ptlib.pc
+/revision.h

--- a/src/ptlib/unix/svcproc.cxx
+++ b/src/ptlib/unix/svcproc.cxx
@@ -217,7 +217,7 @@ int PServiceProcess::InitialiseService()
     pid_t pid;
 
     {
-      ifstream pidfile(pidfilename);
+      ifstream pidfile((string&) pidfilename);
       if (!pidfile.is_open()) {
         cout << "Could not open pid file: \"" << pidfilename << "\""
                 " - " << strerror(errno) << endl;
@@ -384,7 +384,7 @@ int PServiceProcess::InitialiseService()
   // Run as a daemon, ie fork
 
   if (!pidfilename) {
-    ifstream pidfile(pidfilename);
+    ifstream pidfile((string&) pidfilename);
     if (pidfile.is_open()) {
       pid_t pid;
       pidfile >> pid;
@@ -412,7 +412,7 @@ int PServiceProcess::InitialiseService()
       cout << "Daemon started with pid " << pid << endl;
       if (!pidfilename) {
         // Write out the child pid to magic file in /var/run (at least for linux)
-        ofstream pidfile(pidfilename);
+        ofstream pidfile((string&) pidfilename);
         if (pidfile.is_open())
           pidfile << pid;
         else


### PR DESCRIPTION
When compiling on a Mac, I only got one error: it complained that the ifstream and ofstream constructors were ambiguous between char * and string&. I was not certain whether it should be string& or char *, so I picked string& and it at least compiled. 